### PR TITLE
ci(release-prepare): quote workflow name to fix YAML parse error

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@
 # and the existing release.yml workflow takes over to build artifacts and
 # create the GitHub Release.
 
-name: Release: prepare
+name: "Release: prepare"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- The freshly-merged release-prepare workflow has invalid YAML on line 7: `name: Release: prepare` is parsed as a nested key because of the unquoted colon. GitHub Actions refuses to load the file and the workflow can't be triggered.
- Wrapping the value in double quotes makes it a single scalar string and the workflow parses cleanly.

## Test plan

- [x] Verified the diff is a single-line change to `.github/workflows/release-prepare.yml`.
- [ ] Confirm the workflow appears under *Actions → Release: prepare* once this PR merges (currently it's missing because of the parse error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)