### PR TITLE
feat(release): publish bo4e-cli to Homebrew via bo4e/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,14 +299,61 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          repository: "bo4e/homebrew-tap"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@v8
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   announce:
     needs:
       - plan
       - host
+      - publish-homebrew-formula
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,19 @@ lto = "thin"
 
 # cargo-dist release pipeline.
 #   * `installers` lists the user-facing install methods generated as release artifacts.
-#     We're starting with the no-PAT shape: shell installer (curl-pipe-sh),
-#     PowerShell installer (irm-pipe-iex), and a Windows MSI. Tarballs/zips for
-#     every target are emitted automatically. Homebrew tap + Scoop bucket can be
-#     added later once those repos exist.
+#     Shell installer (curl-pipe-sh), PowerShell installer (irm-pipe-iex), Windows MSI,
+#     and a Homebrew formula published to a tap (see `tap` / `publish-jobs` below).
+#     Tarballs/zips for every target are emitted automatically. Scoop bucket can be
+#     added later once that repo exists.
 #   * `targets` defines the cross-compile matrix. We cover the major desktop
 #     platforms; add aarch64-unknown-linux-gnu later if ARM Linux users show up.
+#   * `tap` is the GitHub repo cargo-dist commits the generated Homebrew formula
+#     into on every tagged release. The tap must exist under `bo4e/homebrew-tap`
+#     and the release workflow needs a `HOMEBREW_TAP_TOKEN` secret with write
+#     access to it (see release.yml).
+#   * `publish-jobs = ["homebrew"]` opts the Homebrew formula push into the
+#     publish phase. macOS + linux-gnu bottles fall out of the existing target
+#     matrix, so `brew install bo4e/tap/bo4e-cli` works on both.
 #   * `pr-run-mode = "plan"` makes release.yml only *plan* on PRs (no upload),
 #     so opening a PR doesn't burn artifact storage. Uploads happen on tag push.
 #   * `install-path` chooses the binary install location for the shell/PS scripts
@@ -30,7 +37,9 @@ lto = "thin"
 [workspace.metadata.dist]
 cargo-dist-version = "0.31.0"
 ci = "github"
-installers = ["shell", "powershell", "msi"]
+installers = ["shell", "powershell", "msi", "homebrew"]
+tap = "bo4e/homebrew-tap"
+publish-jobs = ["homebrew"]
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
@@ -42,4 +51,6 @@ install-path = "CARGO_HOME"
 # release.yml carries a hand-edited CHANGELOG pre-flight check (see the
 # `HAND-EDITED` markers in that file). `allow-dirty = ["ci"]` tells dist to
 # accept the modification instead of refusing every `plan` / `host` run.
+# To regenerate release.yml via `dist generate --mode=ci`, comment this line
+# out, run the regenerate, re-apply the HAND-EDITED block, then restore.
 allow-dirty = ["ci"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Download the latest `bo4e-cli-x86_64-pc-windows-msvc.msi` from the
 [Releases page](https://github.com/bo4e/BO4E-CLI/releases/latest) and double-click it.
 The CLI then appears under *Apps & Features*.
 
+### macOS / Linux — Homebrew
+
+```bash
+brew install bo4e/tap/bo4e-cli
+```
+
+The first run automatically taps `bo4e/homebrew-tap` (equivalent to
+`brew tap bo4e/tap && brew install bo4e-cli`). Works on macOS (Intel and Apple
+Silicon) and on x86_64 Linux via [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).
+
 ### Manual download
 
 Each release also ships raw tarballs (`.tar.xz` / `.zip`) for every supported target —
@@ -71,8 +81,8 @@ bo4e --version
 bo4e --help
 ```
 
-> Homebrew tap and Scoop bucket distribution may be added later; until then please use
-> one of the channels above.
+> Scoop bucket distribution may be added later; until then Windows users should use
+> the PowerShell or MSI installer above.
 
 ### Slim install with only the generators you need
 
@@ -98,6 +108,7 @@ The binary is removable in one step from every channel it shipped with:
 | Linux / macOS shell installer | run the `uninstall` script that the installer placed next to the binary, or simply `rm $(which bo4e)`           |
 | Windows PowerShell installer  | re-run the installer URL with `-Uninstall`, or delete `bo4e.exe` from the install prefix shown by the installer |
 | Windows MSI                   | *Apps & Features* → *bo4e-cli* → *Uninstall*                                                                    |
+| Homebrew (macOS / Linux)      | `brew uninstall bo4e-cli` (optionally `brew untap bo4e/tap`)                                                    |
 | Manual download               | delete the binary you copied out of the tarball                                                                 |
 | `cargo install` / `binstall`  | `cargo uninstall bo4e-cli`                                                                                      |
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -114,13 +114,13 @@ Every CLI command implements the `cli::base::Executable` trait. `main.rs` is a t
 - **Closure-based, object-safe `Visitable`** for schema tree traversal. Avoids `RefCell`-style runtime borrow checking; supports early termination via `ControlFlow`. Used by the `edit` transforms and by `diff` walkers.
 - **Console singleton with sentinel markup.** The CLI uses a `OnceLock<Console>` so every print site (including in libraries that the CLI calls into) renders through one highlighter. `--verbose` / `--quiet` filter by `Level`. Warnings/errors always go to stderr and are never suppressed (info goes to stdout).
 - **CHANGELOG by git-cliff + cargo-dist.** `cliff.toml` parses conventional-commit subjects into release sections, then `cargo-dist`'s release workflow embeds the matching `## X.Y.Z` section in GitHub Releases. Keep heading shape stable.
-- **Release pipeline = cargo-dist.** `workspace.metadata.dist` configures installers (shell, PowerShell, MSI) and cross-compile targets. `pr-run-mode = "plan"` means PRs only do a dry-run.
+- **Release pipeline = cargo-dist.** `workspace.metadata.dist` configures installers (shell, PowerShell, MSI, Homebrew) and cross-compile targets. The Homebrew formula is pushed to the `bo4e/homebrew-tap` repo (`tap = "bo4e/homebrew-tap"`, `publish-jobs = ["homebrew"]`), which requires a `HOMEBREW_TAP_TOKEN` repo secret on `BO4E-CLI` with write access to the tap. `pr-run-mode = "plan"` means PRs only do a dry-run.
 
 ## CI and release flow
 
 - `.github/workflows/ci.yml` — fmt, clippy, doc, and test on PRs + pushes to `main`. Tests fan out across macOS and Windows.
 - `.github/workflows/release-prepare.yml` — opens a PR that bumps the workspace version and prepends a new CHANGELOG section.
-- `.github/workflows/release.yml` — driven by cargo-dist; triggered by version tags. Builds binaries, generates installers, attaches them to the GitHub Release.
+- `.github/workflows/release.yml` — driven by cargo-dist; triggered by version tags. Builds binaries, generates installers, attaches them to the GitHub Release, and pushes the generated Homebrew formula to `bo4e/homebrew-tap`. The plan job carries a HAND-EDITED CHANGELOG pre-flight check (preserved through `allow-dirty = ["ci"]`); re-apply it after any `dist generate --mode=ci`.
 
 ## Where to start when adding a new feature
 

--- a/crates/bo4e-cli/Cargo.toml
+++ b/crates/bo4e-cli/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Leon Haffmans <leon.haffmans@hochfrequenz.de>"]
 license = "MIT"
 edition = "2024"
 repository.workspace = true
+homepage = "https://github.com/bo4e/BO4E-CLI"
 
 [package.metadata.wix]
 upgrade-guid = "8830C354-0DA5-4EA8-B8E5-9C4EEC5CD4C9"


### PR DESCRIPTION
## Summary

- Adds the `homebrew` cargo-dist installer alongside shell / PowerShell / MSI so users can `brew install bo4e/tap/bo4e-cli` on macOS (Intel + Apple Silicon) and on x86_64 Linux via [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).
- Wires `tap = "bo4e/homebrew-tap"` + `publish-jobs = ["homebrew"]` into `[workspace.metadata.dist]`. The newly-created [`bo4e/homebrew-tap`](https://github.com/bo4e/homebrew-tap) repo receives an auto-generated `Formula/bo4e-cli.rb` on every tagged release.
- Regenerated `release.yml` via `dist generate --mode=ci`. The HAND-EDITED CHANGELOG pre-flight check and the Dependabot `actions/upload-artifact@v7` / `actions/download-artifact@v8` bumps are re-applied; `allow-dirty = ["ci"]` is restored.
- `crates/bo4e-cli/Cargo.toml` gains a `homepage` field (required for a valid Homebrew formula).
- README + `STRUCTURE.md` updated to reflect the new install channel.

## Required before tagging the next release

- [ ] Mint a PAT with write access to `bo4e/homebrew-tap` (fine-grained PAT, `Contents: write`) and add it as `HOMEBREW_TAP_TOKEN` in this repo's Actions secrets. Without it, the `publish-homebrew-formula` job's `actions/checkout` against the tap fails.

## Test plan

- [x] `dist plan` succeeds and lists `bo4e-cli.rb` plus all four platform artifacts.
- [x] `cargo check --workspace --all-targets` passes.
- [x] `release.yml` diff vs. `main` only adds the `publish-homebrew-formula` job + `announce` gating; hand-edits preserved.
- [x] `bo4e/homebrew-tap` exists, is public, and has a populated `main` branch so `actions/checkout` won't fail on first release.
- [ ] After merging + adding `HOMEBREW_TAP_TOKEN`, tag a release and verify `Formula/bo4e-cli.rb` lands in the tap and `brew install bo4e/tap/bo4e-cli` works on macOS and Linux.

## Notes

- The auto-generated tap commits are authored as `"axo bot" <admin+bot@axo.dev>` (cargo-dist default). If we want a bo4e-branded committer, override `GITHUB_USER` / `GITHUB_EMAIL` in the regenerated `publish-homebrew-formula` job.
- Scoop bucket (Windows) is still on the roadmap; the README disclaimer was narrowed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)