### PR TITLE
fix(diff): detect TypeBase changes on leaf SchemaType variants

### DIFF
--- a/crates/bo4e-cli/src/diff/diff.rs
+++ b/crates/bo4e-cli/src/diff/diff.rs
@@ -460,23 +460,25 @@ fn diff_schema_type(
         // spurious `FieldTypeChanged` even when only the title / description /
         // default actually differs.
         (NumberSchema(o), NumberSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
         (IntegerSchema(o), IntegerSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
         (BooleanSchema(o), BooleanSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
         (NullSchema(o), NullSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
-        (AnySchema(o), AnySchema(n)) => diff_type_base(&o.base, &n.base, old_trace, new_trace, out),
+        (AnySchema(o), AnySchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
+        }
         (DecimalSchema(o), DecimalSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
         (ConstantSchema(o), ConstantSchema(n)) => {
-            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, opts, out)
         }
         _ => diff_schema_differing_types(old, new, old_trace, new_trace, out),
     }
@@ -1098,6 +1100,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1118,6 +1121,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1138,6 +1142,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1158,6 +1163,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1194,6 +1200,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1214,6 +1221,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);
@@ -1250,6 +1258,7 @@ mod tests {
             "/x",
             "/x",
             &m(),
+            &DiffOptions::default(),
             &mut out,
         );
         assert_eq!(out.len(), 1);

--- a/crates/bo4e-cli/src/diff/diff.rs
+++ b/crates/bo4e-cli/src/diff/diff.rs
@@ -397,7 +397,29 @@ fn diff_schema_type(
         (ReferenceSchema(o), ReferenceSchema(n)) => {
             diff_ref_schemas(o, n, old_trace, new_trace, current_module, out)
         }
-        _ if std::mem::discriminant(old) == std::mem::discriminant(new) => {}
+        // Leaf variants below need explicit same-variant arms: without them the
+        // pair would fall through to `diff_schema_differing_types` and emit a
+        // spurious `FieldTypeChanged` even when only the title / description /
+        // default actually differs.
+        (NumberSchema(o), NumberSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
+        (IntegerSchema(o), IntegerSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
+        (BooleanSchema(o), BooleanSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
+        (NullSchema(o), NullSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
+        (AnySchema(o), AnySchema(n)) => diff_type_base(&o.base, &n.base, old_trace, new_trace, out),
+        (DecimalSchema(o), DecimalSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
+        (ConstantSchema(o), ConstantSchema(n)) => {
+            diff_type_base(&o.base, &n.base, old_trace, new_trace, out)
+        }
         _ => diff_schema_differing_types(old, new, old_trace, new_trace, out),
     }
 }
@@ -876,5 +898,184 @@ mod tests {
             out.iter()
                 .any(|c| c.r#type == ChangeType::FieldDefaultChanged)
         );
+    }
+
+    // ── Leaf SchemaType variant changes (regression: same-variant pairs of
+    //    IntegerSchema/NumberSchema/BooleanSchema/NullSchema/ConstantSchema/
+    //    AnySchema/DecimalSchema used to fall through the catch-all
+    //    `_ if discriminant(old) == discriminant(new) => {}` arm in
+    //    diff_schema_type and silently drop every change, including title /
+    //    description / default).
+
+    #[test]
+    fn test_integer_schema_title_change_emits_title_changed() {
+        use bo4e_schemas::models::json_schema::IntegerSchema;
+        let mut a = IntegerSchema::default();
+        let mut b = IntegerSchema::default();
+        a.base.title = Some("Old".into());
+        b.base.title = Some("New".into());
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::IntegerSchema(a),
+            &SchemaType::IntegerSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldTitleChanged);
+    }
+
+    #[test]
+    fn test_number_schema_description_change_emits_description_changed() {
+        use bo4e_schemas::models::json_schema::NumberSchema;
+        let mut a = NumberSchema::default();
+        let mut b = NumberSchema::default();
+        a.base.description = Some("alpha".into());
+        b.base.description = Some("beta".into());
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::NumberSchema(a),
+            &SchemaType::NumberSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldDescriptionChanged);
+    }
+
+    #[test]
+    fn test_boolean_schema_default_change_emits_default_changed() {
+        use bo4e_schemas::models::json_schema::{BooleanSchema, PrimitiveValue};
+        let mut a = BooleanSchema::default();
+        let mut b = BooleanSchema::default();
+        a.base.default = Some(PrimitiveValue::Bool(false));
+        b.base.default = Some(PrimitiveValue::Bool(true));
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::BooleanSchema(a),
+            &SchemaType::BooleanSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldDefaultChanged);
+    }
+
+    #[test]
+    fn test_null_schema_title_change_emits_title_changed() {
+        use bo4e_schemas::models::json_schema::NullSchema;
+        let mut a = NullSchema::default();
+        let mut b = NullSchema::default();
+        a.base.title = Some("Old".into());
+        b.base.title = Some("New".into());
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::NullSchema(a),
+            &SchemaType::NullSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldTitleChanged);
+    }
+
+    #[test]
+    fn test_constant_schema_title_change_emits_title_changed() {
+        use bo4e_schemas::models::json_schema::{ConstantSchema, LiteralTypeString};
+        let a = ConstantSchema {
+            base: TypeBase {
+                description: None,
+                title: Some("Old".into()),
+                default: None,
+            },
+            r#type: LiteralTypeString::String,
+            format: None,
+            constant: "X".into(),
+        };
+        let b = ConstantSchema {
+            base: TypeBase {
+                description: None,
+                title: Some("New".into()),
+                default: None,
+            },
+            r#type: LiteralTypeString::String,
+            format: None,
+            constant: "X".into(),
+        };
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::ConstantSchema(a),
+            &SchemaType::ConstantSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldTitleChanged);
+    }
+
+    #[test]
+    fn test_any_schema_title_change_emits_title_changed() {
+        use bo4e_schemas::models::json_schema::AnySchema;
+        let mut a = AnySchema::default();
+        let mut b = AnySchema::default();
+        a.base.title = Some("Old".into());
+        b.base.title = Some("New".into());
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::AnySchema(a),
+            &SchemaType::AnySchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldTitleChanged);
+    }
+
+    #[test]
+    fn test_decimal_schema_title_change_emits_title_changed() {
+        use bo4e_schemas::models::json_schema::{
+            DecimalSchema, LiteralFormatDecimal, LiteralTypeDecimal,
+        };
+        let a = DecimalSchema {
+            base: TypeBase {
+                description: None,
+                title: Some("Old".into()),
+                default: None,
+            },
+            r#type: LiteralTypeDecimal::Number,
+            format: LiteralFormatDecimal::Decimal,
+        };
+        let b = DecimalSchema {
+            base: TypeBase {
+                description: None,
+                title: Some("New".into()),
+                default: None,
+            },
+            r#type: LiteralTypeDecimal::Number,
+            format: LiteralFormatDecimal::Decimal,
+        };
+        let mut out = vec![];
+        diff_schema_type(
+            &SchemaType::DecimalSchema(a),
+            &SchemaType::DecimalSchema(b),
+            "/x",
+            "/x",
+            &m(),
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].r#type, ChangeType::FieldTitleChanged);
     }
 }


### PR DESCRIPTION
## Summary
- `diff_schema_type` had a catch-all `_ if discriminant(old) == discriminant(new) => {}` arm that silently dropped *every* change for same-variant pairs of the leaf `SchemaType` variants: `NumberSchema`, `IntegerSchema`, `BooleanSchema`, `NullSchema`, `AnySchema`, `DecimalSchema`, `ConstantSchema`.
- In practice this meant a field whose only change was the `title` (or `description`, or `default`) on, say, an `integer` or `boolean` field was reported as **no change at all**. Verified end-to-end against constructed BO4E schemas where only `f_str` showed up before this fix.
- Replace the silent catch-all with explicit same-variant arms that forward each leaf type to `diff_type_base`. The remaining `_ =>` fallback now exclusively handles cross-discriminant pairs via `diff_schema_differing_types`, as originally intended.

## Test plan
- [x] 7 new unit tests cover title/description/default changes for `IntegerSchema`, `NumberSchema`, `BooleanSchema`, `NullSchema`, `ConstantSchema`, `AnySchema`, `DecimalSchema` — all failed before the fix with `0 changes` and pass after.
- [x] `cargo test --workspace --no-fail-fast` green (272 lib tests + every integration suite).
- [x] `cargo fmt --check` clean.
- [x] End-to-end repro with `bo4e diff schemas` on a constructed schema confirms title-only changes are now detected on all leaf integer/number/boolean/null/string fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)