### PR TITLE
ci(clippy): treat warnings as errors + silence too_many_arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
           components: clippy
       - name: Run clippy action
         uses: clechasseur/rs-clippy-check@v5
+        with:
+          args: --workspace --all-targets -- -D warnings
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
   doc:

--- a/crates/bo4e-cli/src/diff/diff.rs
+++ b/crates/bo4e-cli/src/diff/diff.rs
@@ -327,6 +327,11 @@ fn diff_all_of_schemas(
     );
 }
 
+// Eight arguments mirror the other diff walkers (old/new, paired traces,
+// kind, module context, opts, sink) — collapsing any pair into a struct
+// would make the call sites in diff_any_of_schemas / diff_all_of_schemas
+// less readable, not more.
+#[allow(clippy::too_many_arguments)]
 fn diff_variant_list(
     old: &[SchemaType],
     new: &[SchemaType],


### PR DESCRIPTION
## Summary
- Pass `--workspace --all-targets -- -D warnings` to the clippy step in `.github/workflows/ci.yml`. Previously warnings were merely annotated on the PR (e.g. the `clippy::too_many_arguments` lint that surfaced on #158 while CI stayed green) and CI passed regardless; now any warning fails the job.
- Silence the one existing offender — `diff_variant_list` — with a localised `#[allow(clippy::too_many_arguments)]` and a comment explaining why the 8-arg shape is intentional (parity with the other diff walkers' old/new + paired traces + kind + module + opts + sink layout; grouping any pair into a struct would obscure the call sites in `diff_any_of_schemas` / `diff_all_of_schemas`, not clarify them).

## Test plan
- [x] Local `cargo clippy --workspace --all-targets -- -D warnings` exits 0.
- [x] `cargo test -p bo4e-cli --lib` green (267 lib tests).
- [x] CI will now fail on any future clippy warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)