### PR TITLE
ci(test): restore Swatinem/rust-cache before cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,23 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      # Restore must run *before* `cargo test` — Swatinem/rust-cache restores
+      # at the position it appears in. Previously placed after `cargo test`,
+      # which meant the cache was saved on post-job but never restored,
+      # turning every run into a cold compile (≈3m wasted on Windows).
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
       # enable this ci template to run regardless of whether the lockfile is checked in or not
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo test --locked
         run: cargo test --locked --all-features --all-targets
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
+        # Use the bundled rust-lld instead of MSVC link.exe on Windows MSVC
+        # targets; link.exe is the single slowest phase of the test job
+        # there. rust-lld ships with rustup so no extra install needed.
+        env:
+          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
   kroki:
     name: kroki-validation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,6 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test --locked
         run: cargo test --locked --all-features --all-targets
-        # Use the bundled rust-lld instead of MSVC link.exe on Windows MSVC
-        # targets; link.exe is the single slowest phase of the test job
-        # there. rust-lld ships with rustup so no extra install needed.
-        env:
-          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
   kroki:
     name: kroki-validation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Move the `Swatinem/rust-cache@v2` step to *before* `cargo test`. The action restores at the position it appears in. Previously it was placed *after* the build, so the post-job save worked but **no subsequent run ever read the cache back** — every test job ran a full cold compile. The action's own README says to run it "right after checkout and toolchain installation"; this PR does that.

Inspecting one of the pre-fix runs (`#157` on `fix/diff-constant-schema-format`):
- Cache log showed `Cache hit … full match: true` followed by `Cache restored successfully`, but the timestamps put the restore *after* `cargo test` had already finished.
- Both Windows and macOS were effectively cold-compiling 268–271 crates on every run.

## Measured impact

Comparing against the most recent baseline run (PR #157, before this change):

| job | baseline | this PR | Δ |
|---|---|---|---|
| `test windows-latest` | 4m 35s | **2m 32s** | **−45 %** |
| `test macos-latest`   | 1m 57s | **47s**    | **−60 %** |

After the fix, `cargo test` compiles only the three workspace crates (`bo4e-cli`, `bo4e-schemas`, `bo4e-codegen`) — dep artefacts come straight from the restored `target/` dir. The remaining ~20s on Windows is the cache *download* itself, which is the irreducible cost of pulling the ~500 MB cache from GitHub.

## What's not in this PR

The branch's history also contains an experiment that set `CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=rust-lld` for the Windows test step. Two measured runs showed it was both fingerprint-poisonous (every dep recompiled on every run because the linker env var changed cargo's per-crate fingerprint) and not measurably faster than `link.exe` on cold runs (3m 32s–3m 51s vs the 3m 44s baseline). It was reverted in `ead212c`. A proper `rust-lld` or `sccache` experiment can land in a follow-up PR with a fingerprint-aware cache key.

The three commits on the branch could be squash-merged into one — GitHub's "Squash and merge" will do this automatically.

## Test plan
- [x] Two CI runs on this branch measured: Windows `test` job 4m 35s → 2m 32s, macOS `test` job 1m 57s → 47s.
- [x] Verified via the per-job log that the post-fix cache restore now happens *before* `cargo test`, that `cargo test` compiles only 3 crates instead of ~270, and that all other jobs (`fmt`, `clippy`, `doc`, `kroki-validation`) still pass green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
