### PR TITLE
fix(diff): use ∅ instead of - for NonExistent in matrix emote output

### DIFF
--- a/crates/bo4e-cli/src/models/matrix.rs
+++ b/crates/bo4e-cli/src/models/matrix.rs
@@ -10,7 +10,7 @@ lazy_static! {
         (CompatibilitySymbol::ChangeNone,        "\u{1F7E2}".to_string()), // 🟢
         (CompatibilitySymbol::ChangeNonCritical, "\u{1F7E1}".to_string()), // 🟡
         (CompatibilitySymbol::ChangeCritical,    "\u{1F534}".to_string()), // 🔴
-        (CompatibilitySymbol::NonExistent,       "-".to_string()),
+        (CompatibilitySymbol::NonExistent,       "\u{2205}".to_string()), // ∅
         (CompatibilitySymbol::Added,             "\u{2795}".to_string()),  // ➕
         (CompatibilitySymbol::Removed,           "\u{2796}".to_string()),  // ➖
     ]);


### PR DESCRIPTION
## Summary

- The compatibility-matrix emote cell for `NonExistent` was a plain `-`. When the resulting CSV was embedded in Sphinx docs, RST parsed the dash as a bullet-list marker and rendered the cell as a stray bullet.
- Swap the canonical symbol for `∅` (U+2205 EMPTY SET): semantically "module did not exist in this version" and free of RST parsing collisions.
- One-line change in `crates/bo4e-cli/src/models/matrix.rs`. The `COMPATIBILITY_SYMBOLS` BiMap drives both CSV (`Display`) and JSON ((de)serialization), so both outputs now use `∅`.

## Migration note

Diff-matrix JSON files generated by ≤ v1.2.0 contain `"-"` for `NonExistent` and will fail to deserialize against this binary. Diff matrices are regenerated artefacts, so this is expected to be a non-issue in practice — but worth flagging.

## Test plan

- [x] `cargo test --workspace` — 276/276 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Embed a freshly generated emote-mode CSV in a Sphinx page and confirm the `∅` cell no longer renders as a bullet