### PR TITLE
fix(github): drop upper length cap on gh*_ token regex

### DIFF
--- a/crates/bo4e-cli/src/io/github.rs
+++ b/crates/bo4e-cli/src/io/github.rs
@@ -12,7 +12,12 @@ use std::str::FromStr;
 use tokio::task::JoinSet;
 
 lazy_static! {
-    static ref REGEX_GITHUB_TOKEN: regex::Regex = regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap();
+    // The `gh*_` arm intentionally has no upper length bound. GitHub has
+    // grown Actions installation tokens (`ghs_…`) past 400 chars, and the
+    // previous {36,251} cap rejected them before we could even call the
+    // API. Anchoring with `^…$` plus the character class keeps the match
+    // tight; the real authority on token validity is GitHub itself.
+    static ref REGEX_GITHUB_TOKEN: regex::Regex = regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_]{36,}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap();
     static ref REGEX_GITHUB_SRC_PATH: regex::Regex = regex::Regex::new(r"^src/bo4e_schemas/(?P<module>.*)\.json$").unwrap();
 }
 
@@ -319,5 +324,39 @@ mod tests {
             release_exists(v, None)
         }
         let _ = _assert_signature; // silence unused
+    }
+
+    #[test]
+    fn classic_pat_is_valid() {
+        // Classic PATs are 40 chars total: `ghp_` + 36 body chars.
+        let token = format!("ghp_{}", "a".repeat(36));
+        assert!(is_valid_github_token(&token));
+    }
+
+    #[test]
+    fn fine_grained_pat_is_valid() {
+        // `github_pat_` + 22 chars + `_` + 59 chars.
+        let token = format!("github_pat_{}_{}", "a".repeat(22), "b".repeat(59));
+        assert!(is_valid_github_token(&token));
+    }
+
+    #[test]
+    fn long_actions_installation_token_is_valid() {
+        // Regression: GitHub Actions now issues `ghs_…` installation tokens
+        // well over 400 chars. The previous {36,251} cap rejected them, which
+        // broke `bo4e pull` when invoked from a GitHub Actions workflow with
+        // `GITHUB_TOKEN`.
+        let token = format!("ghs_{}", "A".repeat(422));
+        assert_eq!(token.len(), 426);
+        assert!(is_valid_github_token(&token));
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(!is_valid_github_token(""));
+        assert!(!is_valid_github_token("not-a-token"));
+        assert!(!is_valid_github_token("ghp_short"));
+        // Wrong prefix letter (only p/o/u/s/r are accepted after `gh`).
+        assert!(!is_valid_github_token(&format!("ghx_{}", "a".repeat(36))));
     }
 }


### PR DESCRIPTION
## Summary
- Drop the `{36,251}` upper bound on the `gh*_` arm of `REGEX_GITHUB_TOKEN`. GitHub Actions installation tokens (`ghs_…`) have grown past 400 chars, and the validator rejected them before any API call could be made — breaking `bo4e pull` for consumers that forward `secrets.GITHUB_TOKEN` from a workflow.
- Add unit tests for classic PATs, fine-grained PATs, the long-`ghs_` regression case, and a handful of invalid inputs.

## Context
Observed on [BO4E-Python run 26975056997](https://github.com/bo4e/BO4E-python/actions/runs/26975056997) (2026-06-04, `tox -e docs`):

```
[auth] GITHUB_ACCESS_TOKEN=set (len=426, prefix='ghs_', bo4e-regex-valid=False)
…
$ bo4e pull -t v202501.0.0 -o …
error: invalid value '***' for '--token <TOKEN>': Invalid GitHub token.
```

The token is forwarded correctly (`GITHUB_ACCESS_TOKEN` whitelisted via `pass_env` in `tox.ini`, set at the job level in the workflow), but `bo4e-cli`'s `is_valid_github_token` rejects it client-side because the body length (422 chars) exceeds the regex cap of 251.

The body character class (`[A-Za-z0-9_]`) and the `^…$` anchoring keep the match tight without an upper bound, and GitHub itself is the authoritative validator on token validity.

## Test plan
- [x] `cargo test --workspace` — all 33 tests pass, including 4 new `is_valid_github_token` cases:
  - `classic_pat_is_valid` (`ghp_` + 36 chars)
  - `fine_grained_pat_is_valid` (`github_pat_…`)
  - `long_actions_installation_token_is_valid` (`ghs_` + 422 chars, total 426 — the regression)
  - `garbage_is_rejected` (empty, short, wrong prefix)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] After release: bump `setup-bo4e` action in BO4E-Python to the new bo4e-cli tag to unblock docs CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)