### PR TITLE
fix(github): accept JWT-style `ghs_…` Actions installation tokens

### DIFF
--- a/crates/bo4e-cli/src/io/github.rs
+++ b/crates/bo4e-cli/src/io/github.rs
@@ -12,12 +12,14 @@ use std::str::FromStr;
 use tokio::task::JoinSet;
 
 lazy_static! {
-    // The `gh*_` arm intentionally has no upper length bound. GitHub has
-    // grown Actions installation tokens (`ghs_…`) past 400 chars, and the
-    // previous {36,251} cap rejected them before we could even call the
-    // API. Anchoring with `^…$` plus the character class keeps the match
-    // tight; the real authority on token validity is GitHub itself.
-    static ref REGEX_GITHUB_TOKEN: regex::Regex = regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_]{36,}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap();
+    // The `gh*_` arm intentionally has no upper length bound and accepts
+    // the full base64url alphabet plus `.`. GitHub now issues Actions
+    // installation tokens (`ghs_…`) as JWT-encoded blobs — three
+    // base64url segments joined by `.` — which the previous
+    // `[A-Za-z0-9_]` body charset rejected. Anchoring with `^…$` plus
+    // the character class still keeps the match tight; the real
+    // authority on token validity is GitHub itself.
+    static ref REGEX_GITHUB_TOKEN: regex::Regex = regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_.\-]{36,}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap();
     static ref REGEX_GITHUB_SRC_PATH: regex::Regex = regex::Regex::new(r"^src/bo4e_schemas/(?P<module>.*)\.json$").unwrap();
 }
 
@@ -348,6 +350,29 @@ mod tests {
         // `GITHUB_TOKEN`.
         let token = format!("ghs_{}", "A".repeat(422));
         assert_eq!(token.len(), 426);
+        assert!(is_valid_github_token(&token));
+    }
+
+    #[test]
+    fn jwt_style_installation_token_is_valid() {
+        // Regression: GitHub Actions installation tokens are now JWT-encoded
+        // (`header.payload.signature`, three base64url segments joined by
+        // `.`). Confirmed in BO4E-Python's docs CI on 2026-06-05 by sorting
+        // the body chars and finding two `.` near the start. The prior
+        // `[A-Za-z0-9_]` body charset rejected them.
+        let header = "A".repeat(140);
+        let payload = "B".repeat(140);
+        let signature = "C".repeat(140);
+        let token = format!("ghs_{header}.{payload}.{signature}");
+        assert_eq!(token.len(), 426);
+        assert!(is_valid_github_token(&token));
+    }
+
+    #[test]
+    fn base64url_dash_is_valid_in_body() {
+        // base64url uses `-` where base64 uses `+`. JWT signatures and
+        // payloads can contain `-`, so the body charset must accept it.
+        let token = format!("ghs_{}", "a-b_".repeat(40));
         assert!(is_valid_github_token(&token));
     }
 


### PR DESCRIPTION
## Summary
- Widen the `gh*_` body charset from `[A-Za-z0-9_]` to `[A-Za-z0-9_.\-]` (base64url + `.`) so JWT-encoded GitHub Actions installation tokens validate.
- Add two regression tests: a 426-char JWT-shaped `ghs_…` token (`header.payload.signature`) and a body containing `-`.

## Context
Follow-up to #176, which lifted the upper length cap but still rejected the actual `ghs_…` tokens GitHub now hands out. The length wasn't the only thing that changed: GitHub's Actions installation tokens are now JWT-encoded — three base64url segments joined by `.`.

Confirmed empirically on [BO4E-Python run 26999989593](https://github.com/bo4e/BO4E-python/actions/runs/26999989593) (2026-06-05). The docs script prints a sorted-character anagram of the token body for diagnostics, which showed:

```
[auth] GITHUB_ACCESS_TOKEN=set (len=426, prefix='ghs_', bo4e-regex-valid=False,
       body-anagram='..0000…_____aaaa…zzzz')
                     ^^                ^^^^^
                     two dots          underscores stay in alphabet position
```

Two `.` at the very start of the sorted body, consistent with a JWT's `header.payload.signature` separators. The body's character multiset is otherwise just `[A-Za-z0-9_]`, so widening to base64url + `.` covers the current format and future-proofs against base64url-with-dashes payloads.

## Test plan
- [x] `cargo test --workspace` — all tests pass; 2 new validator cases:
  - `jwt_style_installation_token_is_valid` (`ghs_AAAA…(140).BBBB…(140).CCCC…(140)`, total 426)
  - `base64url_dash_is_valid_in_body` (body containing `-`)
- [x] Existing `long_actions_installation_token_is_valid` (#176 regression) still passes.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [ ] After release: bump `setup-bo4e` in BO4E-Python to the new tag, then re-run docs CI on `deps/bo4e-cli` and confirm `bo4e-regex-valid=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)