### PR TITLE
fix(pull): bound GitHub requests with connect + request timeouts

### DIFF
--- a/crates/bo4e-cli/src/io/github.rs
+++ b/crates/bo4e-cli/src/io/github.rs
@@ -12,6 +12,15 @@ use std::io::Read;
 use std::str::FromStr;
 use tar::Archive;
 
+// Bound every GitHub request so a stalled connection fails fast instead of
+// hanging `pull` indefinitely. `REQUEST_TIMEOUT` is the ceiling for a whole
+// request incl. body download; the schema tarball is tiny (~60 KB) so a
+// generous value still bails out long before a user would give up. This is
+// deliberately far higher than the 1.5 s used by the tab-completion client,
+// whose only job is to feel instant.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 const GITHUB_API: &str = "https://api.github.com";
 const OWNER: &str = "bo4e";
 const REPO: &str = "BO4E-Schemas";
@@ -105,6 +114,8 @@ fn build_client(token: Option<&str>) -> Result<Client, String> {
     Client::builder()
         .user_agent(USER_AGENT)
         .default_headers(headers)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
         .build()
         .map_err(|e| format!("failed to build HTTP client: {e}"))
 }


### PR DESCRIPTION
## Problem
`io/github.rs::build_client` built the reqwest client with **no timeout**, so a stalled connection during `pull` (the tarball download or the latest-version lookup) hangs **indefinitely** — the only escape is Ctrl-C. By contrast the tab-completion client already caps itself at 1.5s.

## Fix
Add `.connect_timeout(10s)` and `.timeout(60s)` to the client. The schema tarball is ~60 KB, so 60s is generous headroom for a healthy download on a slow link while still bailing out long before a user would. It's intentionally far higher than the completion client's 1.5s, whose only job is to feel instant.

## Verification
- `cargo test`: 552 passed, 0 failed · `clippy -D warnings` clean · `fmt` clean
- Live `bo4e pull` still fetches all 191 schemas.

Note: retry/backoff on transient 5xx was intentionally left out — that's a behavioral change worth its own discussion; this PR is just the hang fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)