### PR TITLE
chore: replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,6 @@ dependencies = [
  "http",
  "indexmap",
  "indicatif",
- "lazy_static",
  "petgraph",
  "rand 0.10.1",
  "regex",
@@ -203,7 +202,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "itertools",
- "lazy_static",
  "regex",
  "serde",
  "serde_json",
@@ -1002,12 +1000,6 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"

--- a/crates/bo4e-cli/Cargo.toml
+++ b/crates/bo4e-cli/Cargo.toml
@@ -32,7 +32,6 @@ dirs = "6"
 # it needs via feature unification, so "full" is unnecessary bloat.
 tokio = { version = "1.50.0", features = ["rt", "net", "time"] }
 regex = "1.12.3"
-lazy_static = "1.5.0"
 chrono = { version = "0.4.45", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"

--- a/crates/bo4e-cli/src/diff/diff.rs
+++ b/crates/bo4e-cli/src/diff/diff.rs
@@ -6,20 +6,17 @@ use bo4e_schemas::models::json_schema::{
     SchemaType, StrEnumSchema, StringSchema, TypeBase,
 };
 use bo4e_schemas::models::schema_meta::Schemas;
-use lazy_static::lazy_static;
 use regex::Regex;
+use std::sync::LazyLock;
 
-lazy_static! {
-    // Matches any BO4E version string that may appear inline in a description
-    // — clean release tags AND the dirty forms produced by hatch-vcs
-    // (`+g<commit>` and `.d<YYYYMMDD>` suffixes). Used to strip versions out
-    // of descriptions before comparing them, so a documentation URL like
-    // `.../v202401.6.0/...` matching `.../v202401.7.0+gabc.d20260522/...`
-    // doesn't show up as a real field-description change.
-    static ref REGEX_VERSION_IN_DESC: Regex = Regex::new(
-        r"v\d{6}\.\d+\.\d+(?:-rc\d*)?(?:\+g\w+)?(?:\.d\d{8})?"
-    ).unwrap();
-}
+// Matches any BO4E version string that may appear inline in a description
+// — clean release tags AND the dirty forms produced by hatch-vcs
+// (`+g<commit>` and `.d<YYYYMMDD>` suffixes). Used to strip versions out
+// of descriptions before comparing them, so a documentation URL like
+// `.../v202401.6.0/...` matching `.../v202401.7.0+gabc.d20260522/...`
+// doesn't show up as a real field-description change.
+static REGEX_VERSION_IN_DESC: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"v\d{6}\.\d+\.\d+(?:-rc\d*)?(?:\+g\w+)?(?:\.d\d{8})?").unwrap());
 
 const VERSION_DESC_PLACEHOLDER: &str = "{__gh_version__}";
 const VERSION_TITLE_MARKER: &str = " Version";

--- a/crates/bo4e-cli/src/edit/update_refs.rs
+++ b/crates/bo4e-cli/src/edit/update_refs.rs
@@ -2,18 +2,18 @@ use crate::cprint_verbose;
 use bo4e_schemas::models::json_schema::ReferenceSchema;
 use bo4e_schemas::models::schema_meta::{Schema, Schemas};
 use bo4e_schemas::visitable::{Visitable, cntrl_to_result, result_to_cntrl};
-use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::ops::DerefMut;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref REF_ONLINE_REGEX: regex::Regex = regex::Regex::new(
-        r"^https://raw\.githubusercontent\.com/(?:BO4E|bo4e|Bo4e|Hochfrequenz)/BO4E-Schemas/(?P<version>[^/]+)/src/bo4e_schemas/(?P<sub_path>(?:\w+/)*)(?P<model>\w+)\.json#?$"
+static REF_ONLINE_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"^https://raw\.githubusercontent\.com/(?:BO4E|bo4e|Bo4e|Hochfrequenz)/BO4E-Schemas/(?P<version>[^/]+)/src/bo4e_schemas/(?P<sub_path>(?:\w+/)*)(?P<model>\w+)\.json#?$",
     )
-    .unwrap();
-    static ref REF_DEFS_REGEX: regex::Regex =
-        regex::Regex::new(r"^#/\$(?:defs|definitions)/(?P<model>\w+)$").unwrap();
-}
+    .unwrap()
+});
+static REF_DEFS_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^#/\$(?:defs|definitions)/(?P<model>\w+)$").unwrap());
 
 fn update_reference(
     reference: &mut ReferenceSchema,

--- a/crates/bo4e-cli/src/io/github.rs
+++ b/crates/bo4e-cli/src/io/github.rs
@@ -4,12 +4,12 @@ use bo4e_schemas::models::schema_meta::{Schema, Schemas};
 use bo4e_schemas::models::version::Version;
 use flate2::read::GzDecoder;
 use http::StatusCode;
-use lazy_static::lazy_static;
 use reqwest::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};
 use serde::Deserialize;
 use std::io::Read;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use tar::Archive;
 
 const GITHUB_API: &str = "https://api.github.com";
@@ -18,20 +18,21 @@ const REPO: &str = "BO4E-Schemas";
 const USER_AGENT: &str = concat!("bo4e-cli/", env!("CARGO_PKG_VERSION"));
 const GH_API_VERSION: &str = "2022-11-28";
 
-lazy_static! {
-    // The `gh*_` arm intentionally has no upper length bound and accepts
-    // the full base64url alphabet plus `.`. GitHub now issues Actions
-    // installation tokens (`ghs_…`) as JWT-encoded blobs — three
-    // base64url segments joined by `.` — which the previous
-    // `[A-Za-z0-9_]` body charset rejected. Anchoring with `^…$` plus
-    // the character class still keeps the match tight; the real
-    // authority on token validity is GitHub itself.
-    static ref REGEX_GITHUB_TOKEN: regex::Regex = regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_.\-]{36,}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap();
-    // Matches a schema path *relative to the repo root* (the tarball's
-    // top-level `<owner>-<repo>-<sha>/` prefix is stripped first). The
-    // `module` capture keeps sub-directories (`bo/Foo`, `enum/Bar`).
-    static ref REGEX_GITHUB_SRC_PATH: regex::Regex = regex::Regex::new(r"^src/bo4e_schemas/(?P<module>.*)\.json$").unwrap();
-}
+// The `gh*_` arm intentionally has no upper length bound and accepts
+// the full base64url alphabet plus `.`. GitHub now issues Actions
+// installation tokens (`ghs_…`) as JWT-encoded blobs — three
+// base64url segments joined by `.` — which the previous
+// `[A-Za-z0-9_]` body charset rejected. Anchoring with `^…$` plus
+// the character class still keeps the match tight; the real
+// authority on token validity is GitHub itself.
+static REGEX_GITHUB_TOKEN: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"^(gh[pousr]_[A-Za-z0-9_.\-]{36,}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|v[0-9]\.[0-9a-f]{40})$").unwrap()
+});
+// Matches a schema path *relative to the repo root* (the tarball's
+// top-level `<owner>-<repo>-<sha>/` prefix is stripped first). The
+// `module` capture keeps sub-directories (`bo/Foo`, `enum/Bar`).
+static REGEX_GITHUB_SRC_PATH: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^src/bo4e_schemas/(?P<module>.*)\.json$").unwrap());
 
 pub fn is_valid_github_token(token: &str) -> bool {
     REGEX_GITHUB_TOKEN.is_match(token)

--- a/crates/bo4e-cli/src/models/matrix.rs
+++ b/crates/bo4e-cli/src/models/matrix.rs
@@ -1,29 +1,38 @@
 use bimap::BiMap;
 use bo4e_schemas::models::version::DirtyVersion;
 use indexmap::IndexMap;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
+use std::sync::LazyLock;
 
-lazy_static! {
-    pub static ref COMPATIBILITY_SYMBOLS: BiMap<CompatibilitySymbol, String> = BiMap::from_iter([
-        (CompatibilitySymbol::ChangeNone,        "\u{1F7E2}".to_string()), // 🟢
-        (CompatibilitySymbol::ChangeNonCritical, "\u{1F7E1}".to_string()), // 🟡
-        (CompatibilitySymbol::ChangeCritical,    "\u{1F534}".to_string()), // 🔴
-        (CompatibilitySymbol::NonExistent,       "\u{2205}".to_string()), // ∅
-        (CompatibilitySymbol::Added,             "\u{2795}".to_string()),  // ➕
-        (CompatibilitySymbol::Removed,           "\u{2796}".to_string()),  // ➖
-    ]);
+pub static COMPATIBILITY_SYMBOLS: LazyLock<BiMap<CompatibilitySymbol, String>> =
+    LazyLock::new(|| {
+        BiMap::from_iter([
+            (CompatibilitySymbol::ChangeNone, "\u{1F7E2}".to_string()), // 🟢
+            (
+                CompatibilitySymbol::ChangeNonCritical,
+                "\u{1F7E1}".to_string(),
+            ), // 🟡
+            (CompatibilitySymbol::ChangeCritical, "\u{1F534}".to_string()), // 🔴
+            (CompatibilitySymbol::NonExistent, "\u{2205}".to_string()), // ∅
+            (CompatibilitySymbol::Added, "\u{2795}".to_string()),       // ➕
+            (CompatibilitySymbol::Removed, "\u{2796}".to_string()),     // ➖
+        ])
+    });
 
-    pub static ref COMPATIBILITY_TEXTS: BiMap<CompatibilityText, String> = BiMap::from_iter([
-        (CompatibilityText::ChangeNone,        "none".to_string()),
-        (CompatibilityText::ChangeNonCritical, "non-critical".to_string()),
-        (CompatibilityText::ChangeCritical,    "critical".to_string()),
-        (CompatibilityText::NonExistent,       "non-existent".to_string()),
-        (CompatibilityText::Added,             "added".to_string()),
-        (CompatibilityText::Removed,           "removed".to_string()),
-    ]);
-}
+pub static COMPATIBILITY_TEXTS: LazyLock<BiMap<CompatibilityText, String>> = LazyLock::new(|| {
+    BiMap::from_iter([
+        (CompatibilityText::ChangeNone, "none".to_string()),
+        (
+            CompatibilityText::ChangeNonCritical,
+            "non-critical".to_string(),
+        ),
+        (CompatibilityText::ChangeCritical, "critical".to_string()),
+        (CompatibilityText::NonExistent, "non-existent".to_string()),
+        (CompatibilityText::Added, "added".to_string()),
+        (CompatibilityText::Removed, "removed".to_string()),
+    ])
+});
 
 /// Emoji rendering of a compatibility cell.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/bo4e-schemas/Cargo.toml
+++ b/crates/bo4e-schemas/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 chrono = { version = "0.4.45", features = ["serde"] }
 itertools = "0.15.0"
-lazy_static = "1.5.0"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"

--- a/crates/bo4e-schemas/src/models/version.rs
+++ b/crates/bo4e-schemas/src/models/version.rs
@@ -1,24 +1,26 @@
 use chrono::prelude::*;
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref REGEX_VERSION: Regex = Regex::new(
+static REGEX_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
         "^v(?P<major>\\d{6})\\.\
         (?P<functional>\\d+)\\.\
         (?P<technical>\\d+)\
         (?:-rc(?P<candidate>\\d*))?\
         $",
     )
-    .unwrap();
-    // The `+g<commit>` and `.d<YYYYMMDD>` suffixes are independent: `bo4e edit` brands
-    // the output with `.d<date>` even when there is no commit (the input came straight
-    // from a tagged release), so the date suffix must be parseable on its own.
-    static ref REGEX_DIRTY_VERSION: Regex = Regex::new(
+    .unwrap()
+});
+// The `+g<commit>` and `.d<YYYYMMDD>` suffixes are independent: `bo4e edit` brands
+// the output with `.d<date>` even when there is no commit (the input came straight
+// from a tagged release), so the date suffix must be parseable on its own.
+static REGEX_DIRTY_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
         "^v(?P<major>\\d{6})\\.\
         (?P<functional>\\d+)\\.\
         (?P<technical>\\d+)\
@@ -30,8 +32,8 @@ lazy_static! {
         (?P<dirty_workdir_date_day>\\d{2})\
         )?$",
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 /// A version of the BO4E-Schemas.
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
`std::sync::LazyLock` is stable (since Rust 1.80) and the workspace is on edition 2024, so the third-party `lazy_static` macro is redundant.

## Change
Converts all five `lazy_static!` blocks to plain `static … : LazyLock<T> = LazyLock::new(|| …)`:
- `io/github.rs` — token + schema-path regexes
- `diff/diff.rs` — inline-version regex
- `edit/update_refs.rs` — the two `$ref` regexes
- `models/matrix.rs` — the two compatibility `BiMap`s (`pub`)
- `bo4e-schemas/models/version.rs` — the version + dirty-version regexes

Call sites are untouched — `LazyLock<T>` derefs to `T` exactly like `lazy_static`'s generated type. Drops the `lazy_static` dependency from both `bo4e-cli` and `bo4e-schemas` (gone from `Cargo.lock`).

## Verification
- `cargo test`: 552 passed, 0 failed · `clippy -D warnings` clean · `fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)