### PR TITLE
perf(graph): Vec-indexed Louvain instead of HashMap<NodeIndex>

### DIFF
--- a/crates/bo4e-cli/src/graph/cluster.rs
+++ b/crates/bo4e-cli/src/graph/cluster.rs
@@ -15,8 +15,14 @@ pub struct Communities {
 ///
 /// `seed` controls tie-breaking inside the move phase. Node iteration order
 /// is sorted lexicographically by the node's module path for reproducibility.
+///
+/// The graph is built without node removals, so `NodeIndex::index()` is a dense
+/// `0..n`. We key everything on that `usize` and use flat `Vec`s / adjacency
+/// lists instead of hashing `NodeIndex` on every lookup and rescanning all
+/// edges for every node's neighbours.
 pub fn louvain(g: &PetGraph, seed: u64) -> Communities {
-    if g.node_count() == 0 {
+    let n = g.node_count();
+    if n == 0 {
         return Communities {
             of: HashMap::new(),
             modularity: 0.0,
@@ -24,25 +30,28 @@ pub fn louvain(g: &PetGraph, seed: u64) -> Communities {
     }
 
     let weights = build_undirected_weights(g);
-    let degrees = node_degrees(&weights);
+    let adjacency = build_adjacency(&weights, n);
+    let degrees = node_degrees(&weights, n);
     // m = total number of undirected edges (each stored once in `weights`).
     // Blondel et al. define m = (1/2) Σ_{ij} A_{ij} for the full symmetric matrix;
     // since we store each undirected pair exactly once, sum(weights) already equals m.
     let m: f64 = weights.values().sum::<f64>();
     let mut rng = StdRng::seed_from_u64(seed);
 
-    let mut comm: HashMap<NodeIndex, usize> =
-        g.node_indices().enumerate().map(|(i, n)| (n, i)).collect();
+    let mut comm: Vec<usize> = (0..n).collect();
+
+    // Deterministic visiting order: lexicographic by the node's module path.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by(|&a, &b| g[NodeIndex::new(a)].cmp(&g[NodeIndex::new(b)]));
 
     loop {
         let mut moved = false;
-        let mut order: Vec<NodeIndex> = g.node_indices().collect();
-        order.sort_by(|a, b| g[*a].cmp(&g[*b]));
-        for n in order {
-            let current = comm[&n];
-            let best = best_community_for(n, current, &comm, &weights, &degrees, m, &mut rng);
+        for &node in &order {
+            let current = comm[node];
+            let best =
+                best_community_for(node, current, &comm, &adjacency, &degrees, m, n, &mut rng);
             if best != current {
-                comm.insert(n, best);
+                comm[node] = best;
                 moved = true;
             }
         }
@@ -52,109 +61,120 @@ pub fn louvain(g: &PetGraph, seed: u64) -> Communities {
     }
 
     // Compact community ids to 0..k.
-    let mut keys: Vec<usize> = comm.values().copied().collect();
+    let mut keys: Vec<usize> = comm.clone();
     keys.sort_unstable();
     keys.dedup();
     let remap: HashMap<usize, usize> = keys.into_iter().enumerate().map(|(i, k)| (k, i)).collect();
-    let final_comm: HashMap<NodeIndex, usize> = comm.iter().map(|(k, v)| (*k, remap[v])).collect();
-
-    let q = modularity(&final_comm, &weights, &degrees, m);
-    Communities {
-        of: final_comm,
-        modularity: q,
+    for c in comm.iter_mut() {
+        *c = remap[c];
     }
+
+    let q = modularity(&weights, &comm, &degrees, m);
+    let of: HashMap<NodeIndex, usize> = (0..n).map(|i| (NodeIndex::new(i), comm[i])).collect();
+    Communities { of, modularity: q }
 }
 
-fn build_undirected_weights(g: &PetGraph) -> HashMap<(NodeIndex, NodeIndex), f64> {
-    let mut w: HashMap<(NodeIndex, NodeIndex), f64> = HashMap::new();
+/// Summed pairwise edge weights, each undirected pair stored once with the
+/// lower index first. Self-loops are kept under `(i, i)`.
+fn build_undirected_weights(g: &PetGraph) -> HashMap<(usize, usize), f64> {
+    let mut w: HashMap<(usize, usize), f64> = HashMap::new();
     for e in g.edge_indices() {
         let (a, b) = g.edge_endpoints(e).unwrap();
+        let (a, b) = (a.index(), b.index());
         let key = if a <= b { (a, b) } else { (b, a) };
         *w.entry(key).or_insert(0.0) += 1.0;
     }
     w
 }
 
-fn node_degrees(weights: &HashMap<(NodeIndex, NodeIndex), f64>) -> HashMap<NodeIndex, f64> {
-    let mut d: HashMap<NodeIndex, f64> = HashMap::new();
-    for (&(a, b), w) in weights {
+/// Neighbour adjacency list (self-loops excluded, since a node is never its own
+/// neighbour in the move phase). Each undirected pair appears in both endpoints.
+fn build_adjacency(weights: &HashMap<(usize, usize), f64>, n: usize) -> Vec<Vec<(usize, f64)>> {
+    let mut adj: Vec<Vec<(usize, f64)>> = vec![Vec::new(); n];
+    for (&(a, b), &w) in weights {
         if a == b {
-            *d.entry(a).or_insert(0.0) += 2.0 * w;
+            continue;
+        }
+        adj[a].push((b, w));
+        adj[b].push((a, w));
+    }
+    adj
+}
+
+fn node_degrees(weights: &HashMap<(usize, usize), f64>, n: usize) -> Vec<f64> {
+    let mut d = vec![0.0f64; n];
+    for (&(a, b), &w) in weights {
+        if a == b {
+            d[a] += 2.0 * w;
         } else {
-            *d.entry(a).or_insert(0.0) += w;
-            *d.entry(b).or_insert(0.0) += w;
+            d[a] += w;
+            d[b] += w;
         }
     }
     d
 }
 
-fn neighbour_weights(
-    n: NodeIndex,
-    weights: &HashMap<(NodeIndex, NodeIndex), f64>,
-) -> HashMap<NodeIndex, f64> {
-    let mut out: HashMap<NodeIndex, f64> = HashMap::new();
-    for (&(a, b), w) in weights {
-        if a == n && b != n {
-            *out.entry(b).or_insert(0.0) += w;
-        } else if b == n && a != n {
-            *out.entry(a).or_insert(0.0) += w;
-        }
-    }
-    out
-}
-
+#[allow(clippy::too_many_arguments)]
 fn best_community_for(
-    n: NodeIndex,
+    node: usize,
     current: usize,
-    comm: &HashMap<NodeIndex, usize>,
-    weights: &HashMap<(NodeIndex, NodeIndex), f64>,
-    degrees: &HashMap<NodeIndex, f64>,
+    comm: &[usize],
+    adjacency: &[Vec<(usize, f64)>],
+    degrees: &[f64],
     m: f64,
+    n: usize,
     rng: &mut StdRng,
 ) -> usize {
-    let k_i = degrees.get(&n).copied().unwrap_or(0.0);
-    let neighbours = neighbour_weights(n, weights);
+    let k_i = degrees[node];
 
-    let mut sum_in: HashMap<usize, f64> = HashMap::new();
-    let mut sum_tot: HashMap<usize, f64> = HashMap::new();
-    for (&node, &c) in comm {
-        if node == n {
+    // sum_tot[c] = total degree of every node (except `node`) in community c.
+    // Community ids live in 0..n (we only ever reuse existing ids), so a flat
+    // Vec indexed by community id replaces the per-node HashMap.
+    let mut sum_tot = vec![0.0f64; n];
+    for (other, &c) in comm.iter().enumerate() {
+        if other == node {
             continue;
         }
-        *sum_tot.entry(c).or_insert(0.0) += degrees.get(&node).copied().unwrap_or(0.0);
-    }
-    for (&nb, &w) in &neighbours {
-        let c = comm[&nb];
-        *sum_in.entry(c).or_insert(0.0) += w;
+        sum_tot[c] += degrees[other];
     }
 
-    let mut candidates: Vec<usize> = sum_in.keys().copied().collect();
+    // sum_in[c] = total edge weight from `node` into community c. Only the
+    // communities of `node`'s neighbours are touched.
+    let mut sum_in = vec![0.0f64; n];
+    let mut candidates: Vec<usize> = Vec::with_capacity(adjacency[node].len() + 1);
+    for &(nb, w) in &adjacency[node] {
+        let c = comm[nb];
+        if sum_in[c] == 0.0 {
+            candidates.push(c);
+        }
+        sum_in[c] += w;
+    }
     candidates.push(current);
     candidates.sort_unstable();
     candidates.dedup();
 
     let mut best = current;
     let mut best_gain = 0.0;
-    for c in &candidates {
-        let s_in = sum_in.get(c).copied().unwrap_or(0.0);
-        let s_tot = sum_tot.get(c).copied().unwrap_or(0.0);
+    for &c in &candidates {
+        let s_in = sum_in[c];
+        let s_tot = sum_tot[c];
         let gain = s_in / m - (k_i * s_tot) / (2.0 * m * m);
         if (gain - best_gain).abs() < 1e-12 {
             if rng.random::<bool>() {
-                best = *c;
+                best = c;
             }
         } else if gain > best_gain {
             best_gain = gain;
-            best = *c;
+            best = c;
         }
     }
     best
 }
 
 fn modularity(
-    comm: &HashMap<NodeIndex, usize>,
-    weights: &HashMap<(NodeIndex, NodeIndex), f64>,
-    degrees: &HashMap<NodeIndex, f64>,
+    weights: &HashMap<(usize, usize), f64>,
+    comm: &[usize],
+    degrees: &[f64],
     m: f64,
 ) -> f64 {
     if m == 0.0 {
@@ -164,24 +184,20 @@ fn modularity(
     // where L_c = sum of edge weights within community c (unique edges, each counted once),
     // and d_c = sum of node degrees within community c.
     // Blondel et al. 2008, eq. after (1). This avoids double-counting issues.
-    let mut l_c: HashMap<usize, f64> = HashMap::new();
-    let mut d_c: HashMap<usize, f64> = HashMap::new();
-    for (&(a, b), w) in weights {
-        let ca = comm[&a];
-        if ca == comm[&b] {
-            *l_c.entry(ca).or_insert(0.0) += w;
+    let k = comm.iter().copied().max().map(|c| c + 1).unwrap_or(0);
+    let mut l_c = vec![0.0f64; k];
+    let mut d_c = vec![0.0f64; k];
+    for (&(a, b), &w) in weights {
+        if comm[a] == comm[b] {
+            l_c[comm[a]] += w;
         }
     }
-    for (&node, &deg) in degrees {
-        let c = comm[&node];
-        *d_c.entry(c).or_insert(0.0) += deg;
+    for (node, &deg) in degrees.iter().enumerate() {
+        d_c[comm[node]] += deg;
     }
-    let communities: std::collections::HashSet<usize> = comm.values().copied().collect();
     let mut q = 0.0;
-    for c in communities {
-        let lc = l_c.get(&c).copied().unwrap_or(0.0);
-        let dc = d_c.get(&c).copied().unwrap_or(0.0);
-        q += lc / m - (dc / (2.0 * m)).powi(2);
+    for c in 0..k {
+        q += l_c[c] / m - (d_c[c] / (2.0 * m)).powi(2);
     }
     q
 }


### PR DESCRIPTION
## Problem
The Louvain community detection in `graph/cluster.rs` keyed every structure on `HashMap<NodeIndex, _>` / `HashMap<(NodeIndex, NodeIndex), f64>`, and `neighbour_weights` rescanned the **entire** edge-weight map for **every** node — O(V·E) per pass.

## Change
Node indices are a dense `0..n` (the graph is built without removals), so switch to flat `Vec`s indexed by node id plus a real adjacency list. Neighbour lookup drops to O(deg), and all the per-node `HashMap` hashing/allocation is gone.

## Measured (release, best of 3)
Results are **identical** to the old implementation (seeded; community-count checksums matched exactly across old vs new), so this is a pure speedup:

| graph | old (HashMap) | new (Vec) | speedup |
|---|---|---|---|
| ~240 nodes (realistic) | 11.4 ms | 1.5 ms | **7.6×** |
| 2400 nodes (stress) | 1900 ms | 143 ms | **13×** |

Even at the realistic BO4E scale the `graph` command's clustering step goes from ~11 ms to ~1.5 ms, because the old per-node full-edge-scan dominated.

## Verification
- `cargo test`: 552 passed, 0 failed (cluster unit tests + graph pipeline/parity integration tests unchanged and green) · `clippy -D warnings` clean · `fmt` clean.
- Public API (`Communities`, `louvain`) and output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)