### PR TITLE
test(git): fix macOS flake — stop leaving process cwd on a deleted tempdir

### DIFF
--- a/crates/bo4e-cli/src/io/git.rs
+++ b/crates/bo4e-cli/src/io/git.rs
@@ -201,11 +201,42 @@ mod tests {
     use crate::test_lock::CWD_LOCK;
     use std::process::Command;
 
+    /// Holds the cwd lock and restores the process cwd on drop.
+    ///
+    /// Without this, each test left the process cwd pointing at its tempdir,
+    /// which was then deleted when the `TempDir` dropped. The *next* test's
+    /// first `git` spawn therefore ran while the process cwd was a since-deleted
+    /// directory — and on macOS `posix_spawn` fails that with a spurious
+    /// `ENOENT` ("git invocation failed"), the root of this suite's flakiness.
+    /// Linux keeps the directory alive via the open fd, so it never surfaced there.
+    struct CwdGuard {
+        restore_to: std::path::PathBuf,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            // Best-effort restore; runs before the caller's `TempDir` is removed
+            // (guard is the second tuple element, so it drops first), so the
+            // process never sits on a deleted cwd between tests.
+            let _ = std::env::set_current_dir(&self.restore_to);
+        }
+    }
+
     /// Initialize a git repo with 3 tagged commits, acquire the cwd lock, and set
-    /// the process cwd to the tempdir. Returns both so the caller holds them for the
-    /// test's full lifetime — dropping either ends the exclusive window.
-    fn make_git_repo() -> (tempfile::TempDir, std::sync::MutexGuard<'static, ()>) {
-        let guard = CWD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    /// the process cwd to the tempdir. Returns the tempdir plus a [`CwdGuard`] that
+    /// keeps the exclusive window open and restores a valid cwd when dropped.
+    fn make_git_repo() -> (tempfile::TempDir, CwdGuard) {
+        let lock = CWD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Anchor the process cwd to the always-present crate directory before
+        // spawning anything: a prior cwd-mutating test may have left it on a
+        // since-deleted tempdir (see `CwdGuard`), and `chdir` to an absolute
+        // path works even when the current cwd is gone. This is also where the
+        // guard restores it on drop.
+        let anchor = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        std::env::set_current_dir(&anchor).unwrap();
+
         let dir = tempfile::tempdir().unwrap();
         let p = dir.path();
         let run = |args: &[&str]| {
@@ -231,7 +262,13 @@ mod tests {
         run(&["tag", "v202401.1.0"]);
         run(&["tag", "not-a-version"]);
         std::env::set_current_dir(p).unwrap();
-        (dir, guard)
+        (
+            dir,
+            CwdGuard {
+                restore_to: anchor,
+                _lock: lock,
+            },
+        )
     }
 
     #[test]


### PR DESCRIPTION
## Symptom
`test macos-latest` intermittently fails with:
```
thread 'io::git::tests::test_parse_reference_...' panicked at crates/bo4e-cli/src/io/git.rs:
git invocation failed: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
clippy/fmt/doc and the Windows/Linux test jobs always pass.

## Root cause (not what the error suggests)
`git` **is** on PATH on `macos-latest`, and the failing spawn already passes an explicit, valid `.current_dir(tempdir)` — so the `ENOENT` is neither "git missing" nor "tempdir missing". It's the **process** working directory:

- `make_git_repo()` did `std::env::set_current_dir(tempdir)` and never restored it.
- At test end the `TempDir` drops and the directory is **deleted**, but the process cwd still points at it.
- The next test's first `git` spawn then runs while the process cwd is a **deleted** directory. On macOS `posix_spawn` fails that with `ENOENT`; Linux keeps the directory alive through the open fd, which is why it never flaked there.

`Command`'s error is identical (`code: 2, ENOENT`) whether the *program* or the *working directory* can't be resolved (see [rust-lang/rust#37868](https://github.com/rust-lang/rust/issues/37868)), which is what made this look like "git not found."

## Fix
- Anchor the process cwd to `CARGO_MANIFEST_DIR` (always present) at the start of `make_git_repo`, before any spawn — `chdir` to an absolute path works even when the current cwd is gone.
- Add a `CwdGuard` (holds the cwd lock, restores cwd on `Drop`). It's the second tuple element, so it drops **before** the caller's `TempDir`, guaranteeing the process never sits on a deleted cwd between tests.

No production code changes; test-only.

## Verification
- Linux: `io::git` tests pass 3× in a row; full suite **552 passed, 0 failed**; `clippy -D warnings` and `fmt` clean.
- The macOS timing window can't be reproduced in this Linux environment, so the fix is reasoned from the `posix_spawn`/deleted-cwd behaviour rather than observed locally — but it removes the invalid-cwd variable entirely and can't regress the other platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)