### PR TITLE
build: pin Rust toolchain to 1.97.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+# Pin the toolchain so local dev and CI use the same compiler and, crucially,
+# the same clippy lint set. CI installs Rust via `dtolnay/rust-toolchain@stable`
+# (which only runs `rustup default stable`); rustup's directory-override
+# precedence means this file wins at every `cargo`/`clippy`/`fmt` invocation.
+# Without the pin, `@stable` floats to whatever stable is latest at run time, so
+# a new release enabling a lint by default can turn CI red on unchanged code.
+# Bump this deliberately (and fix any newly-surfaced lints in the same PR).
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Why

CI installs Rust via `dtolnay/rust-toolchain@stable`, which floats to whatever stable is latest **at run time**. That is non-deterministic: a new stable release that enables a clippy lint by default can turn CI red on otherwise-unchanged code.

This bit us in #214 — local clippy (1.96.0) was clean, but CI's 1.97.0 enabled `useless_borrows_in_formatting` and failed on pre-existing `format!` borrows.

## What

Add a repo-root `rust-toolchain.toml` pinning `channel = "1.97.0"` with the `clippy` + `rustfmt` components.

The CI action only runs `rustup default stable` (it does not set `RUSTUP_TOOLCHAIN`), and rustup's **directory-override** precedence puts `rust-toolchain.toml` above the default. So this one file pins **both** local dev and CI to the same compiler and lint set — no workflow change needed. Bumping the pin becomes a deliberate PR (fixing any newly-surfaced lints alongside it).

## Verification

With the file in place, `rustup show active-toolchain` reports `1.97.0 (overridden by rust-toolchain.toml)`. Under that pinned toolchain:
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Pinned to the current latest stable (1.97.0), which is what floating `@stable` already resolves to today, so this is behavior-preserving except that it's now deterministic.